### PR TITLE
Document submodule removal and locale change

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -28,6 +28,9 @@ v30.0.00
 
     Changes With Important Notices
 
+        System: removed the i18n submodule. Translation files are now
+        embedded in the core and Chinese (zh_CN) is the default locale
+
     Tweaks & Additions
         Individual Needs: enabled viewing IN records for past students as read-only
         Messenger: enabled resending to any recipient when read receipts are off in Send Report


### PR DESCRIPTION
## Summary
- update changelog with note about embedded translations and default locale

## Testing
- `composer install` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849167fe470832e949d4f24d9417f9e