### PR TITLE
Fix language selection missing options

### DIFF
--- a/src/Forms/DatabaseFormFactory.php
+++ b/src/Forms/DatabaseFormFactory.php
@@ -309,18 +309,11 @@ class DatabaseFormFactory extends FormFactory
         $sql = "SELECT * FROM gibboni18n WHERE active='Y' ORDER BY code";
         $results = $this->pdo->select($sql);
 
-        global $session;
-        $absolutePath = $session->get('absolutePath');
-
         $values = [];
         foreach ($results->fetchAll() as $item) {
-            $installed = isset($item['installed']) && $item['installed'] == 'Y';
-            $filePath = $absolutePath.'/i18n/'.$item['code'].'/LC_MESSAGES/gibbon.mo';
-            if ($installed || file_exists($filePath)) {
-                $values[$item['gibboni18nID']] = $item['systemDefault'] == 'Y'
-                    ? $item['name'].' ('.__('System Default').')'
-                    : $item['name'];
-            }
+            $values[$item['gibboni18nID']] = $item['systemDefault'] == 'Y'
+                ? $item['name'].' ('.__('System Default').')'
+                : $item['name'];
         }
 
         return $this->createSelect($name)->fromArray($values)->placeholder();


### PR DESCRIPTION
## Summary
- don't check for language files when building the language dropdown so installed languages are always listed

## Testing
- `composer test:phpunit` *(fails: `codecept: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684981bb1a08832eb4772edf02b76b5f